### PR TITLE
fix for working with snaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ git clone https://github.com/mellowCS/FirmwareScraper.git
 To run a spider, just go into the project's folder and type the following command into the terminal:
 
 ```
-scrapy crawl *name of spider e.g. avm* -o *name of file to output metadata e.g. spidername.json*
+TMPDIR=$HOME/tmp scrapy crawl *name of spider e.g. avm* -o *name of file to output metadata e.g. spidername.json*
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -68,10 +68,7 @@ All developed spiders and corresponding tests should be contained in the folders
 For the file download, scrapy's file pipline is activated in settings.py. To store the files, a valid path has to be added
 
 ```python
-ITEM_PIPELINES = {<<<<<<< master
-34
- 
-
+ITEM_PIPELINES = {
     'scrapy.pipelines.files.FilesPipeline': 1
 }
 


### PR DESCRIPTION
since firefox and chrom(ium) run on Ubuntu as snap it is need to give scrapy a tmp_dir to work in